### PR TITLE
🔧 Fix: Resolve object disposal issue in SwiftObjectPool by replacing …

### DIFF
--- a/src/SwiftCollections/Pool/DefaultImplementations/SwiftArrayPool.cs
+++ b/src/SwiftCollections/Pool/DefaultImplementations/SwiftArrayPool.cs
@@ -27,7 +27,7 @@ namespace SwiftCollections.Pool
         /// <summary>
         /// Tracks whether the pool has been disposed.
         /// </summary>
-        private bool _disposed;
+        private volatile bool _disposed;
 
         #endregion
 
@@ -165,10 +165,15 @@ namespace SwiftCollections.Pool
 
         private void OnDispose()
         {
-            if (_disposed) return;
+            if (_disposed) 
+                return;
 
-            Clear();
             _disposed = true;
+
+            foreach (var pool in _sizePools.Values)
+                pool.Dispose();
+
+            _sizePools.Clear();
         }
 
         ~SwiftArrayPool() => OnDispose();  // Called by GC if Dispose() wasn't called explicitly.


### PR DESCRIPTION
…ConcurrentBag with ConcurrentStack

- Switched from ConcurrentBag<T> to ConcurrentStack<T> to prevent ThreadLocal disposal errors.
- Marked _disposed as volatile to ensure proper thread visibility.
- Ensured safe disposal of pooled objects, preventing premature access errors.
- Improved overall stability and predictability in multi-threaded environments.